### PR TITLE
head metadata

### DIFF
--- a/library_design/app/views/library_design/head/_head.html.erb
+++ b/library_design/app/views/library_design/head/_head.html.erb
@@ -1,7 +1,6 @@
 <meta charset="utf-8">
 
-<%= content_tag( 'title', @page_title || $SITE_TITLE ) %>
-<%= tag( 'meta', :name => 'description', :content => @description ) %>
+<%= render 'library_design/head/metadata' %>
 
 <%= csrf_meta_tags %>
 <%= csp_meta_tag %>

--- a/library_design/app/views/library_design/head/_metadata.html.erb
+++ b/library_design/app/views/library_design/head/_metadata.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag( 'title', @page_title || $SITE_TITLE ) %>
+<%= tag( 'meta', :name => 'description', :content => @description ) %>
+
+<%# Open Graph -%>
+<%= tag( 'meta', :property => 'og:title', :content => @page_title || $SITE_TITLE ) %>
+<%= tag( 'meta', :property => 'og:description', :content => @description ) %>

--- a/library_design/lib/library_design/version.rb
+++ b/library_design/lib/library_design/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LibraryDesign
-  VERSION = "0.2.16".freeze
+  VERSION = "0.2.17".freeze
 end


### PR DESCRIPTION
- **split metadata out from head for open graph and schema.org and twitter card and etc**
- **bumped version to 0.2.17**
